### PR TITLE
Update Travis setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: php
 
 php:
   - 7.2
+  - 7.3
 
 before_script:
-  - composer --dev install
-    
+  - composer install
+
 script:
-  - phpunit -c phpunit.xml.dist --coverage-text
+  - phpunit --coverage-text

--- a/tests/ExchangeRate/CurrencyConverterApiExchangeRateRetrieverTest.php
+++ b/tests/ExchangeRate/CurrencyConverterApiExchangeRateRetrieverTest.php
@@ -54,11 +54,12 @@ final class CurrencyConverterApiExchangeRateRetrieverTest extends TestCase
 
     /**
      * @test
-     * @expectedException \ExchangeRate\CurrencyConverterApiException
-     * @expectedExceptionMessage Sorry, currency "FOO" not found in list of currencies.
      */
     public function it_should_throw_if_the_currency_can_not_be_found()
     {
+        $this->expectException(CurrencyConverterApiException::class);
+        $this->expectExceptionMessage('Sorry, currency "FOO" not found in list of currencies.');
+
         /** @var ResponseInterface $response */
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->willReturn(200);

--- a/tests/ExchangeRate/FixerIoExchangeRateRetrieverTest.php
+++ b/tests/ExchangeRate/FixerIoExchangeRateRetrieverTest.php
@@ -54,11 +54,12 @@ final class FixerIoExchangeRateRetrieverTest extends TestCase
 
     /**
      * @test
-     * @expectedException \ExchangeRate\FixerIoException
-     * @expectedExceptionMessage Sorry, unable to retrieve exchange rates from Fixer.io.
      */
     public function it_should_throw_if_the_response_is_not_successful()
     {
+        $this->expectException(FixerIoException::class);
+        $this->expectExceptionMessage('Sorry, unable to retrieve exchange rates from Fixer.io.');
+
         /** @var ResponseInterface $response */
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->willReturn(200);
@@ -77,11 +78,12 @@ final class FixerIoExchangeRateRetrieverTest extends TestCase
 
     /**
      * @test
-     * @expectedException \ExchangeRate\FixerIoException
-     * @expectedExceptionMessage Sorry, currency "FOO" not found in list of currencies.
      */
     public function it_should_throw_if_the_currency_can_not_be_found()
     {
+        $this->expectException(FixerIoException::class);
+        $this->expectExceptionMessage('Sorry, currency "FOO" not found in list of currencies.');
+
         /** @var ResponseInterface $response */
         $response = $this->prophesize(ResponseInterface::class);
         $response->getStatusCode()->willReturn(200);


### PR DESCRIPTION
# Changed log
- Enhance Travis CI build setting.
- Since latest stable PHPUnit version is released, using the expected exception annotation will have the deprecated warning message.
Using the related `expectException` methods call instead.